### PR TITLE
Add CAPI to the Cluster Management product

### DIFF
--- a/pkg/capi/config/capi.ts
+++ b/pkg/capi/config/capi.ts
@@ -1,26 +1,13 @@
-import { CAPI_PRODUCT_NAME } from '../types/capi';
+const CLUSTER_MGMT_PRODUCT = 'manager';
 
 export function init($plugin: any, store: any) {
   const {
-    product,
     basicType,
     // weightType,
+    weightGroup,
     virtualType,
     // headers,
-  } = $plugin.DSL(store, CAPI_PRODUCT_NAME);
-
-  product({
-    inStore:             'management',
-    icon:                'gear',
-    weight:  100,
-    to:                  {
-      name:   `${ CAPI_PRODUCT_NAME }-c-cluster-dashboard`,
-      params: {
-        product: CAPI_PRODUCT_NAME,
-        cluster: 'local'
-      }
-    }
-  });
+  } = $plugin.DSL(store, CLUSTER_MGMT_PRODUCT);
 
   virtualType({
     label:       'CAPI Turtles',
@@ -29,14 +16,23 @@ export function init($plugin: any, store: any) {
     namespaced:  false,
     weight:      99,
     route:                  {
-      name:   `${ CAPI_PRODUCT_NAME }-c-cluster-dashboard`,
-      params: {
-        product: CAPI_PRODUCT_NAME,
-        cluster: 'local'
-      }
+      name:   `c-cluster-${ CLUSTER_MGMT_PRODUCT }-capi`,
+      params: { cluster: '_' }
     },
-    overview: true
+    overview: true,
+    exact:    true,
   });
 
-  basicType(['capi-dashboard']);
+  // Interestingly, types can only appear in one place, so by adding machine deployment
+  // and others here, they will no longer show up in the Advanced section, which is
+  // quite nice for this use case
+  basicType([
+    'capi-dashboard',
+    'cluster.x-k8s.io.machinedeployment',
+    'cluster.x-k8s.io.machineset',
+    'cluster.x-k8s.io.machine'
+  ], 'CAPITurtles');
+
+  // Ensure CAPI group appears before the Advanced group
+  weightGroup('CAPITurtles', 10, true);
 }

--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -12,3 +12,7 @@ capi:
     disableAction: Disable CAPI Auto-Import
   warnings:
     embeddedFeatureFlag: "It looks like the Rancher-managed cluster API feature is disabled. To provision and manage RKE2 clusters you must either enable the embedded-cluster-api feature flag or install the Rancher Turtles extension."
+
+nav:
+  group:
+    CAPITurtles: CAPI

--- a/pkg/capi/routes/capi-routing.ts
+++ b/pkg/capi/routes/capi-routing.ts
@@ -1,17 +1,12 @@
-import { CAPI_PRODUCT_NAME } from '../types/capi';
 import Dashboard from '../pages/index.vue';
 
 const BLANK_CLUSTER = '_';
 
 const routes = [
   {
-    name:      `${ CAPI_PRODUCT_NAME }-c-cluster-dashboard`,
-    path:      `/${ CAPI_PRODUCT_NAME }/c/:cluster/dashboard`,
+    name:      'c-cluster-manager-capi',
+    path:      '/c/:cluster/manager/capi',
     component: Dashboard,
-    meta:      {
-      product: CAPI_PRODUCT_NAME,
-      cluster: BLANK_CLUSTER
-    }
   },
 ];
 


### PR DESCRIPTION
Example of having the CAPI extension appear within the Cluster Manager product.

<img width="421" alt="image" src="https://github.com/rancher/capi-ui-extension/assets/1955897/1671ff6b-b62f-4d05-8c82-e419808a7225">
