### PR TITLE
Add auto-import table action to clusters; improve post-install redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "capi-ui",
-  "description": "UI for the CAPI Turtles extension",
+  "description": "UI for CAPI cluster provisioning using the Rancher Turtles extension",
+  "rancher": { "annotations": { "catalog.cattle.io/display-name": "Rancher Turtles" } },
   "version": "0.1.0",
   "private": false,
   "engines": {

--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -3,7 +3,7 @@ capi:
     title: Rancher Turtles
     description: The Rancher Turtles operator allows users to import CAPI-provisioned clusters into Rancher.
     disableFeatureFlag: The <code>embedded-cluster-api</code> feature flag must be disabled before installing the CAPI Turtles extension. Follow instructions in the documentation <a aria-label="Read how to disable the embedded CAPI feature flag" target="_blank" rel="noopener noreferrer nofollow" href="https://docs.rancher-turtles.com/docs/getting-started/rancher#setting-up-rancher-for-rancher-turtles">here</a> to do so.
-    turtlesNeeded: Either the user doesn't have permission to run the Turtles extension or the Turtles operator isn't installed. To install the Rancher Turtles extension, read the <a aria-label="Read how to install the Rancher Turtles operator" href="https://docs.rancher-turtles.com/docs/getting-started/install_turtles_operator" target="_blank" rel="noopener noreferrer nofollow">documentation.</a>
+    turtlesNeeded: Either the user doesn't have permission to run the Turtles extension or the Turtles operator isn't installed. To learn how to install the Rancher Turtles extension, read the <a aria-label="Read how to install the Rancher Turtles operator" href="https://docs.rancher-turtles.com/docs/getting-started/install_turtles_operator" target="_blank" rel="noopener noreferrer nofollow">documentation.</a>
   autoImport:
     label: CAPI Auto-Import
     checkbox:

--- a/pkg/capi/pages/index.vue
+++ b/pkg/capi/pages/index.vue
@@ -6,34 +6,26 @@ import { CAPI } from '../types/capi.ts';
 export default {
   name: 'CAPITurtlesDashboard',
 
-  middleware({ redirect, route, store } ) {
-    // store.dispatch('management/find', {
-    //   type: SCHEMA,
-    //   id:   CAPI.CLUSTER_CLASS,
-    //   opt:  { force: true },
-    // }).then((schema) => {
-    //   return redirect({
-    //     name:   'c-cluster-product-resource',
-    //     params: {
-    //       ...route.params,
-    //       cluster:  '_',
-    //       resource: RANCHER_CAPI.CAPI_CLUSTER,
-    //       product:  'manager'
-    //     }
-    //   });
-    // }).catch();
-
-    if (!!store.getters['management/schemaFor'](CAPI.CLUSTER_CLASS)) {
-      return redirect({
-        name:   'c-cluster-product-resource',
-        params: {
-          ...route.params,
-          cluster:  '_',
-          resource: RANCHER_CAPI.CAPI_CLUSTER,
-          product:  'manager'
-        }
+  async middleware({ redirect, route, store } ) {
+    try {
+      const clusterClassSchema = await store.dispatch('management/find', {
+        type: SCHEMA,
+        id:   CAPI.CLUSTER_CLASS,
+        opt:  { force: true },
       });
-    }
+
+      if (clusterClassSchema) {
+        return redirect({
+          name:   'c-cluster-product-resource',
+          params: {
+            ...route.params,
+            cluster:  '_',
+            resource: RANCHER_CAPI.CAPI_CLUSTER,
+            product:  'manager'
+          }
+        });
+      }
+    } catch {}
   },
 
   components: { Banner },
@@ -92,10 +84,6 @@ export default {
   align-items: center;
   text-align: center;
   margin: 100px 0;
-
-  // & .banner.warning {
-  //   width: fit-content;
-  // }
 
   .description {
     line-height: 20px;

--- a/pkg/capi/pages/index.vue
+++ b/pkg/capi/pages/index.vue
@@ -1,5 +1,5 @@
 <script>
-import { MANAGEMENT, CAPI as RANCHER_CAPI } from '@shell/config/types';
+import { MANAGEMENT, CAPI as RANCHER_CAPI, SCHEMA } from '@shell/config/types';
 import Banner from '@components/Banner/Banner.vue';
 import { CAPI } from '../types/capi.ts';
 
@@ -7,6 +7,22 @@ export default {
   name: 'CAPITurtlesDashboard',
 
   middleware({ redirect, route, store } ) {
+    // store.dispatch('management/find', {
+    //   type: SCHEMA,
+    //   id:   CAPI.CLUSTER_CLASS,
+    //   opt:  { force: true },
+    // }).then((schema) => {
+    //   return redirect({
+    //     name:   'c-cluster-product-resource',
+    //     params: {
+    //       ...route.params,
+    //       cluster:  '_',
+    //       resource: RANCHER_CAPI.CAPI_CLUSTER,
+    //       product:  'manager'
+    //     }
+    //   });
+    // }).catch();
+
     if (!!store.getters['management/schemaFor'](CAPI.CLUSTER_CLASS)) {
       return redirect({
         name:   'c-cluster-product-resource',
@@ -76,6 +92,10 @@ export default {
   align-items: center;
   text-align: center;
   margin: 100px 0;
+
+  // & .banner.warning {
+  //   width: fit-content;
+  // }
 
   .description {
     line-height: 20px;

--- a/pkg/capi/util/auto-import.ts
+++ b/pkg/capi/util/auto-import.ts
@@ -1,0 +1,18 @@
+import { LABELS } from '../types/capi';
+
+export default function(resource: any) {
+  if (resource?.metadata?.labels?.[LABELS.AUTO_IMPORT] === 'true') {
+    delete resource.metadata.labels[LABELS.AUTO_IMPORT];
+  } else {
+    resource.metadata.labels[LABELS.AUTO_IMPORT] = 'true';
+  }
+  try {
+    resource.save();
+  } catch (err) {
+    const title = resource.t('resource.errors.update', { name: resource.name });
+
+    resource.$dispatch('growl/error', {
+      title, message: err, timeout: 5000
+    }, { root: true });
+  }
+}


### PR DESCRIPTION
* add add/remove auto-import label to the `cluster.x-k8s.io.cluster` table
* improve the redirect away from the initial capi index so a hard refresh is not required to detect the schema used to check for a capi operator installation
* add a plugin name and description