### PR TITLE
hide capi machine list until rancher/shell fix is in

### DIFF
--- a/pkg/capi/config/capi.ts
+++ b/pkg/capi/config/capi.ts
@@ -34,7 +34,8 @@ export function init($plugin: any, store: any) {
     RANCHER_CAPI.CAPI_CLUSTER,
     TURTLES_CAPI.CLUSTER_CLASS,
     TURTLES_CAPI.PROVIDER,
-    RANCHER_CAPI.MACHINE,
+    // keep this page hidden under 'advanced' still as it may fail to load in Rancher <=2.8.0, see https://github.com/rancher/dashboard/issues/9973
+    // RANCHER_CAPI.MACHINE,
     RANCHER_CAPI.MACHINE_SET,
     RANCHER_CAPI.MACHINE_DEPLOYMENT,
   ], 'CAPITurtles');


### PR DESCRIPTION
The CAPI machine table fails to load in some cases specific to Rancher turtles, see https://github.com/rancher/dashboard/pull/9974