### PR TITLE
configure vscode to use project typescript version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
vscode built-in typescript is a major version ahead of what we're using in this project (inherited from rancher/dashboard). Adding this file configures vscode to use the correct ts version. Once this is added navigate to a .ts file in vscode, hit cmd+shift+p to open the command palette, type 'restart ts' you should see an option to restart the ts server.