### PR TITLE
add clusterclass action to create cluster from class

### DIFF
--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -1,3 +1,5 @@
+action:
+  createCluster: Create Cluster
 capi:
   installation:
     title: Rancher Turtles

--- a/pkg/capi/models/cluster.x-k8s.io.clusterclass.js
+++ b/pkg/capi/models/cluster.x-k8s.io.clusterclass.js
@@ -1,0 +1,33 @@
+import SteveModel from '@shell/plugins/steve/steve-class';
+import { CAPI } from '@shell/config/types';
+import { BLANK_CLUSTER, QUERY_PARAMS } from '../types/capi';
+
+export default class ClusterClass extends SteveModel {
+  get _availableActions() {
+    const out = super._availableActions;
+
+    out.unshift({
+      action:   'goToCreateCluster',
+      label:   this.t('action.createCluster'),
+      icon:     'icon icon-plus',
+      enabled:  true
+    });
+
+    return out;
+  }
+
+  goToCreateCluster() {
+    const escapedID = escape(this.id);
+    const location = {
+      name:   'c-cluster-product-resource-create',
+      params: {
+        cluster:  BLANK_CLUSTER,
+        product:  'manager',
+        resource: CAPI.CAPI_CLUSTER
+      },
+      query: { [QUERY_PARAMS.CLASS]: escapedID }
+    };
+
+    this.currentRouter().push(location);
+  }
+}

--- a/pkg/capi/types/capi.ts
+++ b/pkg/capi/types/capi.ts
@@ -1,5 +1,7 @@
 export const CAPI_PRODUCT_NAME = 'capi-turtles';
 
+export const QUERY_PARAMS = { CLASS: 'class' };
+
 export const BLANK_CLUSTER = '_';
 
 export const LABELS = { AUTO_IMPORT: 'cluster-api.cattle.io/rancher-auto-import' };


### PR DESCRIPTION
This PR adds an action to cluster classes to create a cluster from the class. The action should navigate the user to the cluster.x-k8s.io.cluster creation page, with a query param indicating the ID of the cluster class.

![Screen Shot 2024-01-12 at 3 11 42 PM](https://github.com/rancher/capi-ui-extension/assets/42977925/660f1fe6-255c-4bb0-b35f-8c9bd717d0df)
