### PR TITLE
hide edit cluster and view cluster config

### DIFF
--- a/pkg/capi/models/cluster.x-k8s.io.cluster.js
+++ b/pkg/capi/models/cluster.x-k8s.io.cluster.js
@@ -1,0 +1,27 @@
+import SteveModel from '@shell/plugins/steve/steve-class';
+import {
+  _YAML,
+  AS,
+} from '@shell/config/query-params';
+
+export default class CapiCluster extends SteveModel {
+  get canEditYaml() {
+    return false;
+  }
+
+  get canUpdate() {
+    return false;
+  }
+
+  get detailLocation() {
+    const location = super._detailLocation;
+
+    return { ...location, query: { [AS]: _YAML } };
+  }
+
+  get _availableActions() {
+    const out = super._availableActions;
+
+    return out.filter(action => action.action !== 'goToEdit' && action.action !== 'goToViewConfig');
+  }
+}


### PR DESCRIPTION
This PR limits the table actions for capi clusters:
* clicking a cluster's name should go to a yaml view
* no edit or edit yaml options
* clone should go to config view