### PR TITLE
[FIX] Fixed bad import

### DIFF
--- a/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
+++ b/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
@@ -2,7 +2,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { set, clone } from '@shell/utils/object';
 import { clear } from '@shell/utils/array';
-import LabeledInput from '@components/Form/LabeledInput/LabeledInput';
+import LabeledInput from '@shell/components/Form/LabeledInput/LabeledInput.vue';
 import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
 import FormValidation from '@shell/mixins/form-validation';
 import Loading from '@shell/components/Loading.vue';

--- a/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
+++ b/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
@@ -2,7 +2,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { set, clone } from '@shell/utils/object';
 import { clear } from '@shell/utils/array';
-import LabeledInput from '@shell/components/Form/LabeledInput/LabeledInput.vue';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
 import FormValidation from '@shell/mixins/form-validation';
 import Loading from '@shell/components/Loading.vue';


### PR DESCRIPTION
yarn build-pkg capi is failing because it cannot find this dependency.