### PR TITLE
[FIX] Made version field required for custom provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rancher/components": "0.1.3",
-    "@rancher/shell": "0.5.3",
+    "@rancher/shell": "2.0.0",
     "@types/lodash": "4.14.196",
     "core-js": "3.21.1",
     "css-loader": "6.7.3"

--- a/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
+++ b/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
@@ -117,7 +117,7 @@ export default (Vue as VueConstructor<
     fvExtraRules() {
       return {
         name:    providerNameValidator(this.$store.getters['i18n/t']),
-        version: providerVersionValidator(this.$store.getters['i18n/t']),
+        version: providerVersionValidator(this.$store.getters['i18n/t'], this.isCustom),
         url:     urlValidator(this.$store.getters['i18n/t'])
       };
     },
@@ -213,9 +213,7 @@ export default (Vue as VueConstructor<
         this.value.spec.credentials = null;
       }
       try {
-        await this.save();
-
-        return this.done();
+        await this.save(btnCb, null);
       } catch (err) {
         this.errors.push(err);
         btnCb(false);
@@ -297,6 +295,7 @@ export default (Vue as VueConstructor<
             label-key="capi.provider.version.label"
             placeholder-key="capi.provider.version.placeholder"
             :rules="fvGetAndReportPathRules('spec.version')"
+            required
           />
         </div>
       </div>

--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -169,7 +169,7 @@ validation:
   pattern: '"{key}" must match the pattern <code>{pattern}</code>.'
   stringFormat: '"{key}" must be a valid {format}.'
   uniqueItems: '"{key}" may not contain duplicate elements.'
-  version: Version format must match format for this provisioner.
+  version: "Version format  should be in the semver format prefixed with 'v'. Example: v1.9.3"
   name: Name is required and must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
   port: Port value must be a number.
   url: '"Value" must be a valid URL.' 

--- a/pkg/capi/package.json
+++ b/pkg/capi/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "rancher": {
     "annotations": {
-      "catalog.cattle.io/rancher-version": ">= v2.8.0",
+      "catalog.cattle.io/rancher-version": ">= 2.9.0-0",
       "catalog.cattle.io/display-name": "CAPI UI",
       "catalog.cattle.io/experimental": "true"
     }

--- a/pkg/capi/util/validators.ts
+++ b/pkg/capi/util/validators.ts
@@ -159,8 +159,8 @@ export const urlValidator = function(t: Translation): Validator {
   return (val: string) => val && !val.match(/^https?:\/\/(.*)$/) ? t('validation.url') : undefined;
 };
 
-export const providerVersionValidator = function(t: Translation): Validator {
-  return (val: string) => val && !val.match(/^(\.*\w*)*$/) ? t('validation.version') : undefined;
+export const providerVersionValidator = function(t: Translation, required: boolean): Validator {
+  return (val: string) => (required && !val) || (val && !val.match(/^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/)) ? t('validation.version') : undefined;
 };
 
 export const providerNameValidator = function(t: Translation): Validator {


### PR DESCRIPTION
Fixes #60 
- Made version mandatory for a custom provider
- Changed save behavior to prevent error swallowing