### PR TITLE
Allow clusterClass yaml editor create multiple resources

### DIFF
--- a/pkg/capi/models/cluster.x-k8s.io.clusterclass.js
+++ b/pkg/capi/models/cluster.x-k8s.io.clusterclass.js
@@ -1,5 +1,5 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { CAPI } from '@shell/config/types';
+import { CAPI, MANAGEMENT, LOCAL_CLUSTER } from '@shell/config/types';
 import { BLANK_CLUSTER, QUERY_PARAMS } from '../types/capi';
 
 export default class ClusterClass extends SteveModel {
@@ -29,5 +29,10 @@ export default class ClusterClass extends SteveModel {
     };
 
     this.currentRouter().push(location);
+  }
+
+  saveYaml(yaml) {
+    const localCluster = this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
+    return localCluster.doAction('apply', { yaml });
   }
 }


### PR DESCRIPTION
Fixes #61 

Side note: I think we should revisit this in the future to add some indication as to which resources have been provisioned like we do in "Import YAML". There is probably more we can do with error handling as well, so I think it's a broader topic we should look into. We should also allow something similar for Providers because some providers would need control plane and bootstrap provider etc that need to be created together and it's not very intuitive. 