### PR TITLE
Fix vsphere provider, add IPAM provider type

### DIFF
--- a/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
+++ b/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
@@ -42,7 +42,7 @@ const customProviderSpec = {
   version:      ''
 };
 
-const providerTypes = ['infrastructure', 'bootstrap', 'controlPlane', 'addon' ];
+const providerTypes = ['infrastructure', 'bootstrap', 'controlPlane', 'addon'];
 
 interface Secret {
   metadata: {
@@ -95,9 +95,7 @@ export default defineComponent({
     });
   },
   data() {
-    const providerDetails: Provider = PROVIDER_TYPES.find(p => p.id === this.provider) || {
-      needCredentials: false, disabled: false, id: '0'
-    };
+    const providerDetails: Provider = PROVIDER_TYPES.find(p => p.id === this.provider) || { disabled: false, id: '0' };
 
     return {
       loading:            true,
@@ -108,8 +106,8 @@ export default defineComponent({
         { path: 'spec.fetchConfig.url', rules: ['url'] },
       ],
       allNamespaces:         [],
-      needCredential:     providerDetails?.needCredentials || false,
-      
+      credentialComponent:     providerDetails?.credential,
+
     };
   },
   computed: {
@@ -122,10 +120,12 @@ export default defineComponent({
       };
     },
     typeOptions() {
-      return providerTypes.map((type)=>{return {label: this.t(`capi.provider.type.${type}.label`), value: type}});
-    },        
+      return providerTypes.map((type) => {
+        return { label: this.t(`capi.provider.type.${ type }.label`), value: type };
+      });
+    },
     showForm() {
-      return !!this.value.spec.credentials.rancherCloudCredentialNamespaceName || !this.needCredential;
+      return !!this.value.spec.credentials.rancherCloudCredentialNamespaceName || !this.credentialComponent;
     },
     isCreate() {
       return this.mode === _CREATE;
@@ -146,7 +146,7 @@ export default defineComponent({
       return this.isEdit && (this.hasFeatures || this.hasVariables);
     },
     waitingForCredential() {
-      return this.needCredential && !this.value.spec.credentials.rancherCloudCredentialNamespaceName;
+      return this.credentialComponent && !this.value.spec.credentials.rancherCloudCredentialNamespaceName;
     }
   },
   methods:  {
@@ -212,7 +212,7 @@ export default defineComponent({
       if ( this.errors ) {
         clear(this.errors);
       }
-      if ( !this.needCredential && !this.value.spec?.credentials?.rancherCloudCredentialNamespaceName ) {
+      if ( !this.credentialComponent && !this.value.spec?.credentials?.rancherCloudCredentialNamespaceName ) {
         this.value.spec.credentials = null;
       }
       try {
@@ -316,18 +316,18 @@ export default defineComponent({
         </div>
       </div>
     </div>
-    <div v-if="needCredential" class="mb-40" />
+    <div v-if="credentialComponent" class="mb-40" />
     <h2 v-if="hasFeatures || hasVariables" class="mb-20">
       <t k="capi.provider.secret.title" />
     </h2>
-    <div v-if="needCredential">
+    <div v-if="credentialComponent">
       <h3 class="mb-20">
         <t k="capi.provider.cloudCredential.title" />
       </h3>
       <SelectCredential
         v-model="value.spec.credentials.rancherCloudCredentialNamespaceName"
         :mode="mode"
-        :provider="provider"
+        :provider="credentialComponent"
         :cancel="cancelCredential"
         :showing-form="showForm"
         class="mb-40"

--- a/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
+++ b/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
@@ -42,7 +42,7 @@ const customProviderSpec = {
   version:      ''
 };
 
-const providerTypes = ['infrastructure', 'bootstrap', 'controlPlane', 'addon'];
+const providerTypes = ['infrastructure', 'bootstrap', 'controlPlane', 'addon', 'ipam', 'runtimeextension', 'core'];
 
 interface Secret {
   metadata: {

--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -102,6 +102,12 @@ capi:
         label: Control Plane
       addon:
         label: Add-On
+      ipam:
+        label: IPAM
+      runtimeextension:
+        label: Runtime Extension
+      core:
+        label: Core
     version:
       label: Version
       placeholder: eg. v1.0.0

--- a/pkg/capi/types/capi.ts
+++ b/pkg/capi/types/capi.ts
@@ -69,29 +69,25 @@ export interface ClusterClass {
 export interface Provider {
   id: string,
   disabled: boolean,
-  needCredentials: boolean
+  credential?: string
 }
 
 export const PROVIDER_TYPES: Provider[] = [
   {
-    id: 'aws', disabled: false, needCredentials: true
+    id: 'aws', disabled: false, credential: 'aws'
   },
   {
-    id: 'azure', disabled: false, needCredentials: true
+    id: 'azure', disabled: false, credential: 'azure'
   },
   {
-    id: 'digitalocean', disabled: false, needCredentials: true
+    id: 'digitalocean', disabled: false, credential: 'digitalocean'
+  },
+  { id: 'docker', disabled: false },
+  {
+    id: 'gcp', disabled: false, credential: 'gcp'
   },
   {
-    id: 'docker', disabled: false, needCredentials: false
+    id: 'vsphere', disabled: false, credential: 'vmwarevsphere'
   },
-  {
-    id: 'gcp', disabled: false, needCredentials: true
-  },
-  {
-    id: 'vsphere', disabled: false, needCredentials: true
-  },
-  {
-    id: 'custom', disabled: false, needCredentials: false
-  },
+  { id: 'custom', disabled: false },
 ];


### PR DESCRIPTION
https://github.com/rancher/capi-ui-extension/issues/87
https://github.com/rancher/capi-ui-extension/issues/86

I added providerTypes based off this error:
![Screenshot 2024-09-10 at 9 14 23 AM](https://github.com/user-attachments/assets/ef9ceb99-c0f5-44e7-a398-89dd7275ef4e)


This PR also updates the ProviderConfig component so that capi providers can use a cloud credential component that does not necessarily match the provider id capi expects, eg  capi expects `vsphere` but our credential component uses `vmwarevsphere`