### PR TITLE
pin build-extension-charts to use workflow from @rancher/shell 2.0.2

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   build-extension-charts:
-    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@master
+    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@shell-pkg-v2.0.2
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Fixes the error seen here https://github.com/rancher/capi-ui-extension/actions/runs/11668836513/job/32489404557