### PR TITLE
remove experimental label from capi ui extension card and add a readme

### DIFF
--- a/pkg/capi/README.md
+++ b/pkg/capi/README.md
@@ -1,0 +1,6 @@
+# CAPI Provisioning
+
+
+### **The CAPI UI extension is in tech preview.**
+
+Create clusters using the Cluster API and automatically import them into Rancher. The Turtles chart must be installed in the local Rancher cluster for the CAPI UI extension to work. Read more about the Rancher Turtles project [here](https://turtles.docs.rancher.com/turtles/next/en/index.html).

--- a/pkg/capi/package.json
+++ b/pkg/capi/package.json
@@ -7,7 +7,6 @@
     "annotations": {
       "catalog.cattle.io/rancher-version": ">= 2.10.0-0",
       "catalog.cattle.io/display-name": "CAPI UI",
-      "catalog.cattle.io/experimental": "true",
       "catalog.cattle.io/ui-extensions-version": ">= 3.0.0 < 4.0.0"
     }
   },


### PR DESCRIPTION
- removed experimental label
- added readme: this will show up in the 'detail' section of the side panel when choosing a new extension version to install, eg: 
![Screenshot 2025-02-11 at 9 53 58 AM](https://github.com/user-attachments/assets/92f4099c-dbb7-41d7-89b0-22a8f0bc2c5c)
