### PR TITLE
Fix control plane version validator; update service and pod CIDR placeholders

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "core-js": "3.21.1",
     "css-loader": "6.7.3",
     "ip": "2.0.1",
-    "node-polyfill-webpack-plugin": "^3.0.0"
+    "node-polyfill-webpack-plugin": "^3.0.0",
+    "semver": "7.5.4"
   },
   "resolutions": {
     "**/webpack": "5",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "@rancher/components": "^0.3.0-alpha.1",
     "@rancher/shell": "3.0.2-rc.2",
     "@types/lodash": "4.14.196",
-    "cache-loader": "^4.1.0",
+    "cache-loader": "4.1.0",
     "color": "4.2.3",
     "core-js": "3.21.1",
     "css-loader": "6.7.3",
     "ip": "2.0.1",
-    "node-polyfill-webpack-plugin": "^3.0.0",
+    "node-polyfill-webpack-plugin": "3.0.0",
     "semver": "7.5.4"
   },
   "resolutions": {

--- a/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
+++ b/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
@@ -195,7 +195,7 @@ export default {
       return this.clusterClassObj?.spec?.workers?.machinePools?.map( (w) => w.class);
     },
     controlPlane() {
-      return this.clusterClassObj?.spec?.controlPlane?.ref?.name;
+      return this.clusterClassObj?.spec?.controlPlane?.ref?.kind;
     },
     clusterClassOptions() {
       const out = [];

--- a/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
+++ b/pkg/capi/edit/cluster.x-k8s.io.cluster/ClusterConfig.vue
@@ -8,7 +8,7 @@ import CruResource from '@shell/components/CruResource.vue';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import ClusterClassVariables from '../../components/CCVariables/index.vue';
 import {
-  versionTest, versionValidator, hostValidator, portValidator, cidrValidator, cidrArrayValid
+  versionValidator, hostValidator, portValidator, cidrValidator, cidrArrayValid
 } from '../../util/validators';
 
 import CardGrid from '../../components/CardGrid.vue';
@@ -163,10 +163,11 @@ export default {
     },
     stepConfigurationRequires() {
       const nameValid = !!this.value.metadata.name;
-      const versionTestString = versionTest(this.$store.getters['i18n/t'], this.controlPlane);
-      const versionValid = this.value?.spec?.topology?.version && !!(this.value?.spec?.topology?.version.match(versionTestString));
-      const controlPlaneEndpointPortValid = !portValidator(this.$store.getters['i18n/t'])(this.value?.spec?.controlPlaneEndpoint?.port);
-      const controlPlaneEndpointHostValid = !hostValidator(this.$store.getters['i18n/t'])(this.value?.spec?.controlPlaneEndpoint?.host);
+      const t = this.$store.getters['i18n/t'];
+
+      const versionValid = this.value?.spec?.topology?.version && !versionValidator(t, this.controlPlane)(this.value?.spec?.topology?.version);
+      const controlPlaneEndpointPortValid = !portValidator(t)(this.value?.spec?.controlPlaneEndpoint?.port);
+      const controlPlaneEndpointHostValid = !hostValidator(t)(this.value?.spec?.controlPlaneEndpoint?.host);
       const machineDeploymentsValid = this.value?.spec?.topology?.workers?.machineDeployments?.length > 0 && !!this.value?.spec?.topology?.workers?.machineDeployments[0]?.name && !!this.value?.spec?.topology?.workers?.machineDeployments[0]?.class;
       const machinePoolsValid = this.value?.spec?.topology?.workers?.machinePools?.length > 0 && !!this.value?.spec?.topology?.workers?.machinePools[0]?.name && !!this.value?.spec?.topology?.workers?.machinePools[0]?.class;
       const networkPodsValid = !this.value?.spec?.clusterNetwork?.pods?.cidrBlocks || cidrArrayValid(this.value.spec.clusterNetwork.pods.cidrBlocks);

--- a/pkg/capi/edit/cluster.x-k8s.io.cluster/NetworkSection.vue
+++ b/pkg/capi/edit/cluster.x-k8s.io.cluster/NetworkSection.vue
@@ -72,6 +72,7 @@ export default {
           :protip="false"
           :mode="mode"
           :title="t('capi.cluster.networking.pods')"
+          :value-placeholder="t('capi.cluster.networking.cidrplaceholder')"
           :rules="rules.pods"
         />
       </div>
@@ -81,6 +82,7 @@ export default {
           :protip="false"
           :mode="mode"
           :title="t('capi.cluster.networking.services')"
+          :value-placeholder="t('capi.cluster.networking.cidrplaceholder')"
           :rules="rules.services"
         />
       </div>

--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -52,6 +52,7 @@ capi:
       serviceDomain: Service Domain
       pods: Pod CIDR Blocks
       services: Service VIP CIDR Blocks
+      cidrplaceholder: e.g. 192.168.0.0/16
     controlPlaneEndpoint:
       title: Control Plane Endpoint
       host: Host

--- a/pkg/capi/types/capi.ts
+++ b/pkg/capi/types/capi.ts
@@ -15,8 +15,8 @@ export const CAPI = {
 };
 
 export const CP_VERSIONS = {
-  'kubekey-k3s':        ['k3s1', 'k3s2'],
-  'rke2-control-plane':          ['rke2r1', 'rke2r2']
+  KThreesControlPlaneTemplate:        ['k3s1', 'k3s2'],
+  RKE2ControlPlaneTemplate:          ['rke2r1', 'rke2r2']
 };
 
 export const CREDENTIALS_UPDATE_REQUIRED = ['aks'];

--- a/pkg/capi/types/capi.ts
+++ b/pkg/capi/types/capi.ts
@@ -15,8 +15,8 @@ export const CAPI = {
 };
 
 export const CP_VERSIONS = {
-  'kubekey-k3s': ['k3s1', 'k3s2'],
-  rke2:          ['rke2r1', 'rke2r2']
+  'kubekey-k3s':        ['k3s1', 'k3s2'],
+  'rke2-control-plane':          ['rke2r1', 'rke2r2']
 };
 
 export const CREDENTIALS_UPDATE_REQUIRED = ['aks'];

--- a/pkg/capi/util/validators.ts
+++ b/pkg/capi/util/validators.ts
@@ -201,33 +201,25 @@ const stringFormatValidators = function (
 
 export const isDefined = (val: any) => val || val === false || !isEmpty(val);
 
-// export const versionTest = function(t: Translation, type: string): RegExp {
-//   let ending = '';
-
-//   if (CP_VERSIONS[type as keyof typeof CP_VERSIONS]) {
-//     ending = `${ CP_VERSIONS[type as keyof typeof CP_VERSIONS].join('|') }`;
-//   }
-
-//   const out = new RegExp(`^v\d+\d+\+(${ ending }$)`);
-// console.log('*** new regex', out)
-// console.log('*** type', type)
-
-//   return out
-// };
-
 export const versionValidator = function (
   t: Translation,
   type: string
 ): Validator {
   return (version: string) => {
-    const validBuilds = CP_VERSIONS[type as keyof typeof CP_VERSIONS];
-
     try {
-      const verObj = semver.parse(version);
-      if(validBuilds){
-        return validBuilds.includes(verObj?.build?.[0]) ? '' : t("validation.version")
+      if (!version || !version.startsWith("v")) {
+        return t("validation.version");
       }
-      
+
+      const validBuilds = CP_VERSIONS[type as keyof typeof CP_VERSIONS];
+
+      const parsedVersion = semver.parse(version);
+      if (validBuilds) {
+        return validBuilds.includes(parsedVersion?.build?.[0])
+          ? ""
+          : t("validation.version");
+      }
+      return parsedVersion ? "" : t("validation.version");
     } catch {
       return t("validation.version");
     }

--- a/pkg/capi/util/validators.ts
+++ b/pkg/capi/util/validators.ts
@@ -1,10 +1,14 @@
-import { Validator, ValidationOptions } from '@shell/utils/validators/formRules';
-import { Translation } from '@shell/types/t';
-import isEmpty from 'lodash/isEmpty';
-import { isIpv4 } from '@shell/utils/string';
-import { isValidCIDR, isValidMac } from '@shell/utils/validators/cidr';
-import formRulesGenerator from '@shell/utils/validators/formRules/index';
-import { CP_VERSIONS } from './../types/capi';
+import {
+  Validator,
+  ValidationOptions,
+} from "@shell/utils/validators/formRules";
+import { Translation } from "@shell/types/t";
+import isEmpty from "lodash/isEmpty";
+import { isIpv4 } from "@shell/utils/string";
+import { isValidCIDR, isValidMac } from "@shell/utils/validators/cidr";
+import formRulesGenerator from "@shell/utils/validators/formRules/index";
+import { CP_VERSIONS } from "./../types/capi";
+import semver from "semver";
 
 /**
  *
@@ -14,7 +18,11 @@ import { CP_VERSIONS } from './../types/capi';
  *
  * @returns an array of validator functions that work with the form-validation mixin. These can be supplied to any component wth the labeled-form-element mixin using the rules prop
  */
-export const openAPIV3SchemaValidators = function(t: Translation, { key = 'Value' }: ValidationOptions, openAPIV3Schema: any): Validator[] {
+export const openAPIV3SchemaValidators = function (
+  t: Translation,
+  { key = "Value" }: ValidationOptions,
+  openAPIV3Schema: any
+): Validator[] {
   const {
     exclusiveMinimum,
     exclusiveMaximum,
@@ -27,42 +35,79 @@ export const openAPIV3SchemaValidators = function(t: Translation, { key = 'Value
     pattern,
     uniqueItems,
     required: requiredFields,
-    format
+    format,
   } = openAPIV3Schema;
 
   const out = [] as any[];
 
   if (maximum) {
     if (exclusiveMaximum) {
-      out.push((val: string | number) => Number(val) >= Number(maximum) ? t('validation.exclusiveMaxValue', { key, maximum }) : undefined);
+      out.push((val: string | number) =>
+        Number(val) >= Number(maximum)
+          ? t("validation.exclusiveMaxValue", { key, maximum })
+          : undefined
+      );
     } else {
-      out.push((val: string | number) => Number(val) > Number(maximum) ? t('validation.maxValue', { key, max: maximum }) : undefined);
+      out.push((val: string | number) =>
+        Number(val) > Number(maximum)
+          ? t("validation.maxValue", { key, max: maximum })
+          : undefined
+      );
     }
   }
 
   if (minimum !== undefined) {
     if (exclusiveMinimum) {
-      out.push((val: string | number) => Number(val) <= Number(minimum) ? t('validation.exclusiveMinValue', { key, minimum }) : undefined);
+      out.push((val: string | number) =>
+        Number(val) <= Number(minimum)
+          ? t("validation.exclusiveMinValue", { key, minimum })
+          : undefined
+      );
     } else {
-      out.push((val: string | number) => Number(val) < Number(minimum) ? t('validation.minValue', { key, min: minimum }) : undefined);
+      out.push((val: string | number) =>
+        Number(val) < Number(minimum)
+          ? t("validation.minValue", { key, min: minimum })
+          : undefined
+      );
     }
   }
   if (minLength !== undefined) {
-    out.push((val: string) => val && val.length < Number(minLength) ? t('validation.minLength', { key, min: minLength }) : undefined);
+    out.push((val: string) =>
+      val && val.length < Number(minLength)
+        ? t("validation.minLength", { key, min: minLength })
+        : undefined
+    );
   }
   if (maxLength) {
-    out.push((val: string) => val && val.length > Number(maxLength) ? t('validation.maxLength', { key, max: maxLength }) : undefined);
+    out.push((val: string) =>
+      val && val.length > Number(maxLength)
+        ? t("validation.maxLength", { key, max: maxLength })
+        : undefined
+    );
   }
   if (maxItems) {
-    out.push((val: any[]) => val && val.length > maxItems ? t('validation.maxItems', { key, maxItems }) : undefined);
+    out.push((val: any[]) =>
+      val && val.length > maxItems
+        ? t("validation.maxItems", { key, maxItems })
+        : undefined
+    );
   }
 
   if (minItems !== undefined) {
-    out.push((val: any[]) => val && val.length < minItems ? t('validation.minItems', { key, minItems }) : undefined);
+    out.push((val: any[]) =>
+      val && val.length < minItems
+        ? t("validation.minItems", { key, minItems })
+        : undefined
+    );
   }
 
   if (pattern) {
-    out.push(regexValidator(t('validation.pattern', { key, pattern }), new RegExp(pattern)));
+    out.push(
+      regexValidator(
+        t("validation.pattern", { key, pattern }),
+        new RegExp(pattern)
+      )
+    );
   }
 
   if (format && stringFormatValidators(t, { key }, format)) {
@@ -70,18 +115,33 @@ export const openAPIV3SchemaValidators = function(t: Translation, { key = 'Value
   }
 
   if (uniqueItems) {
-    out.push((val: any[]) => val && val.filter((item, index) => val.indexOf(item) !== index).length ? t('validation.uniqueItems', { key }) : undefined);
+    out.push((val: any[]) =>
+      val && val.filter((item, index) => val.indexOf(item) !== index).length
+        ? t("validation.uniqueItems", { key })
+        : undefined
+    );
   }
 
   if (requiredFields) {
-    out.push((val: any) => requiredFields.find((key: string) => val[key] === undefined) ? t('validation.requiredFields', { key, requiredFields: requiredFields.toString() }) : undefined);
+    out.push((val: any) =>
+      requiredFields.find((key: string) => val[key] === undefined)
+        ? t("validation.requiredFields", {
+            key,
+            requiredFields: requiredFields.toString(),
+          })
+        : undefined
+    );
   }
 
   return out;
 };
 
-const regexValidator = function(errorMessage: string, regexp: RegExp ): Validator {
-  return (val: string) => val && !val.match(regexp) ? errorMessage : undefined;
+const regexValidator = function (
+  errorMessage: string,
+  regexp: RegExp
+): Validator {
+  return (val: string) =>
+    val && !val.match(regexp) ? errorMessage : undefined;
 };
 
 // strings can be evaluated against regular expressions by defining 'pattern' or validated against a common set of regexp using 'format'
@@ -93,76 +153,125 @@ const regexValidator = function(errorMessage: string, regexp: RegExp ): Validato
  *
  * @returns a form validator for the string format, OR undefined if the format specified is invalid or a format we're not validating for practical reasons
  */
-const stringFormatValidators = function(t: Translation, { key = 'Value' }: ValidationOptions, format: string): Validator | undefined {
-  const formRules = formRulesGenerator(t, { key } );
-  const errorMessage = t('validation.stringFormat', { key, format });
+const stringFormatValidators = function (
+  t: Translation,
+  { key = "Value" }: ValidationOptions,
+  format: string
+): Validator | undefined {
+  const formRules = formRulesGenerator(t, { key });
+  const errorMessage = t("validation.stringFormat", { key, format });
 
   // there are actually 24 formats in total validated on the backend with some odd options eg ISBN, creditcard
   // this subset of formats are the most universal, which we can be confident we are validating correctly
   switch (format) {
-  case 'hostname':
-    return (val: string) => formRules.wildcardHostname(val);
-  case 'ipv4':
-    return (val: string) => val && !isIpv4(val) ? errorMessage : undefined;
-  case 'cidr':
-    return (val: string) => val && !isValidCIDR(val) ? errorMessage : undefined;
-  case 'mac':
-    return (val: string) => val && !isValidMac(val) ? errorMessage : undefined;
-  case 'uuid':
-    return regexValidator(errorMessage, /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i);
-  case 'uuid3':
-    return regexValidator(errorMessage, /^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i);
-  case 'uuid4':
-    return regexValidator(errorMessage, /^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$/i);
-  case 'uuid5':
-    return regexValidator(errorMessage, /^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$/i);
-  default:
-    return undefined;
+    case "hostname":
+      return (val: string) => formRules.wildcardHostname(val);
+    case "ipv4":
+      return (val: string) => (val && !isIpv4(val) ? errorMessage : undefined);
+    case "cidr":
+      return (val: string) =>
+        val && !isValidCIDR(val) ? errorMessage : undefined;
+    case "mac":
+      return (val: string) =>
+        val && !isValidMac(val) ? errorMessage : undefined;
+    case "uuid":
+      return regexValidator(
+        errorMessage,
+        /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i
+      );
+    case "uuid3":
+      return regexValidator(
+        errorMessage,
+        /^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i
+      );
+    case "uuid4":
+      return regexValidator(
+        errorMessage,
+        /^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$/i
+      );
+    case "uuid5":
+      return regexValidator(
+        errorMessage,
+        /^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$/i
+      );
+    default:
+      return undefined;
   }
 };
 
-export const isDefined = (val: any) => (val || val === false) || !isEmpty(val);
+export const isDefined = (val: any) => val || val === false || !isEmpty(val);
 
-export const versionTest = function(t: Translation, type: string): RegExp {
-  let ending = '';
+// export const versionTest = function(t: Translation, type: string): RegExp {
+//   let ending = '';
 
-  if (CP_VERSIONS[type as keyof typeof CP_VERSIONS]) {
-    ending = `\\+(${ CP_VERSIONS[type as keyof typeof CP_VERSIONS].join('|') })`;
-  }
+//   if (CP_VERSIONS[type as keyof typeof CP_VERSIONS]) {
+//     ending = `${ CP_VERSIONS[type as keyof typeof CP_VERSIONS].join('|') }`;
+//   }
 
-  return new RegExp(`^v(\\d+.){2}\\d+${ ending }$`);
+//   const out = new RegExp(`^v\d+\d+\+(${ ending }$)`);
+// console.log('*** new regex', out)
+// console.log('*** type', type)
+
+//   return out
+// };
+
+export const versionValidator = function (
+  t: Translation,
+  type: string
+): Validator {
+  return (version: string) => {
+    const validBuilds = CP_VERSIONS[type as keyof typeof CP_VERSIONS];
+
+    try {
+      const verObj = semver.parse(version);
+      if(validBuilds){
+        return validBuilds.includes(verObj?.build?.[0]) ? '' : t("validation.version")
+      }
+      
+    } catch {
+      return t("validation.version");
+    }
+  };
 };
 
-export const versionValidator = function(t: Translation, type: string): Validator {
-  const test = versionTest(t, type);
-
-  return regexValidator(t('validation.version'), test);
+export const hostValidator = function (t: Translation): Validator {
+  return stringFormatValidators(t, { key: "Host" }, "hostname");
 };
 
-export const hostValidator = function(t: Translation): Validator {
-  return stringFormatValidators(t, { key: 'Host' }, 'hostname');
+export const portValidator = function (t: Translation): Validator {
+  return (val: number) =>
+    val && isNaN(val) ? t("validation.port") : undefined;
 };
 
-export const portValidator = function(t: Translation): Validator {
-  return (val: number) => val && isNaN(val) ? t('validation.port') : undefined;
+export const cidrValidator = function (t: Translation): Validator {
+  return stringFormatValidators(t, { key: "Value" }, "cidr");
 };
-
-export const cidrValidator = function(t: Translation): Validator {
-  return stringFormatValidators(t, { key: 'Value' }, 'cidr');
-};
-export const cidrArrayValid = function(arr: string[]) {
+export const cidrArrayValid = function (arr: string[]) {
   return arr.every((item: string) => {
     return isValidCIDR(item);
   });
 };
-export const urlValidator = function(t: Translation): Validator {
-  return (val: string) => val && !val.match(/^https?:\/\/(.*)$/) ? t('validation.url') : undefined;
+export const urlValidator = function (t: Translation): Validator {
+  return (val: string) =>
+    val && !val.match(/^https?:\/\/(.*)$/) ? t("validation.url") : undefined;
 };
 
-export const providerVersionValidator = function(t: Translation): Validator {
-  return (val: string) => (val && !val.match(/^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/)) ? t('validation.version') : undefined;
+export const providerVersionValidator = function (t: Translation): Validator {
+  return (val: string) =>
+    val &&
+    !val.match(
+      /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+    )
+      ? t("validation.version")
+      : undefined;
 };
 
-export const providerNameValidator = function(t: Translation): Validator {
-  return (val: string) => !val || !val.match(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/) ? t('validation.name') : undefined;
+export const providerNameValidator = function (t: Translation): Validator {
+  return (val: string) =>
+    !val ||
+    !val.match(
+      /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/
+    )
+      ? t("validation.name")
+      : undefined;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12915,6 +12915,13 @@ selfsigned@^2.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
+semver@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.1.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"


### PR DESCRIPTION
#127 
#121


[Turtles documentation ](https://turtles.docs.rancher.com/turtles/stable/en/user/clusterclass.html) has examples of both a clusterclass with an rke2 control plane (the version will need to be suffixed with +rke2r2 or +rke2r1) and an AKS control plane (version shouldn't have a suffix)/



k3s control plane kind is `KThreesControlPlaneTemplate` -  https://github.com/k3s-io/cluster-api-k3s/blob/main/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go

rke2 control plane kind is `RKE2ControlPlaneTemplate` - https://github.com/mantis-toboggan-md/turtles/blob/main/examples/clusterclasses/azure/clusterclass-rke2-example.yaml#L9

![Screenshot 2025-04-04 at 1 24 58 PM](https://github.com/user-attachments/assets/536df38d-2288-49bb-bc3c-03d83ac84af7)
