### PR TITLE
fix: Doc link

### DIFF
--- a/pkg/capi/l10n/en-us.yaml
+++ b/pkg/capi/l10n/en-us.yaml
@@ -4,7 +4,7 @@ capi:
   installation:
     title: Rancher Turtles
     description: The Rancher Turtles operator allows users to import CAPI-provisioned clusters into Rancher.
-    turtlesNeeded: Either the user doesn't have permission to run the Turtles extension or the Turtles operator isn't installed. To learn how to install the Rancher Turtles extension, read the <a aria-label="Read how to install the Rancher Turtles operator" href="https://turtles.docs.rancher.com/turtles/next/en/getting-started/install-rancher-turtles/using_rancher_dashboard.html" target="_blank" rel="noopener noreferrer nofollow">documentation.</a>
+    turtlesNeeded: Either the user doesn't have permission to run the Turtles extension or the Turtles operator isn't installed. To learn how to install the Rancher Turtles extension, read the <a aria-label="Read how to install the Rancher Turtles operator" href="https://turtles.docs.rancher.com/turtles/stable/en/tutorials/quickstart.html#_install_rancher_turtles_using_rancher_dashboard" target="_blank" rel="noopener noreferrer nofollow">documentation.</a>
   autoImport:
     label: CAPI Auto-Import
     checkbox:


### PR DESCRIPTION
Noticed the documentation link returned a 404.