### PR TITLE
Fixed provider edit not working properly in some cases

### DIFF
--- a/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
+++ b/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
@@ -15,7 +15,7 @@ import KeyValue from '@shell/components/form/KeyValue.vue';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import Banner from '@components/Banner/Banner.vue';
-import { _EDIT } from '@shell/config/query-params';
+import { _EDIT, _CREATE } from '@shell/config/query-params';
 import { allHash } from '@shell/utils/promise';
 import { PROVIDER_TYPES, RANCHER_TURTLES_SYSTEM_NAMESPACE, RANCHER_TURTLES_SYSTEM_NAME } from '../../types/capi';
 import { providerNameValidator, providerVersionValidator, urlValidator } from '../../util/validators';
@@ -114,11 +114,14 @@ export default {
       });
     },
     showForm() {
-      return !!this.value.spec.credentials.rancherCloudCredentialNamespaceName || !this.credentialComponent;
+      return !!this.value?.spec?.credentials?.rancherCloudCredentialNamespaceName || !this.credentialComponent;
     },
 
     isEdit() {
       return this.mode === _EDIT;
+    },
+    isCreate() {
+      return this.mode === _CREATE;
     },
     hasFeatures() {
       return !!this.value?.spec?.features;
@@ -133,7 +136,10 @@ export default {
       return this.isEdit && (this.hasFeatures || this.hasVariables);
     },
     waitingForCredential() {
-      return this.credentialComponent && !this.value.spec.credentials.rancherCloudCredentialNamespaceName;
+      return this.credentialComponent && !this.value.spec.credentials?.rancherCloudCredentialNamespaceName;
+    },
+    rancherCloudCredentialNamespaceName() {
+      return this.value.spec?.credentials?.rancherCloudCredentialNamespaceName || '';
     }
   },
   methods:  {
@@ -148,7 +154,7 @@ export default {
           set(this.value, 'spec', { ...clone(customProviderSpec), ...defaultsFromCoreProvider });
         }
       }
-      if (!this.value.spec.configSecret.name) {
+      if (this.isCreate && !this.value.spec.configSecret?.name) {
         set(this.value.spec.configSecret, 'name', this.generateName(this.provider)); // Defines the name of the secret that will be created or adjusted based on the content of the spec.features and spec.variables.
       }
     },
@@ -326,7 +332,7 @@ export default {
         <t k="capi.provider.cloudCredential.title" />
       </h3>
       <SelectCredential
-        v-model:value="value.spec.credentials.rancherCloudCredentialNamespaceName"
+        v-model:value="rancherCloudCredentialNamespaceName"
         :mode="mode"
         :provider="credentialComponent"
         :cancel="cancelCredential"

--- a/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/index.vue
+++ b/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/index.vue
@@ -7,6 +7,8 @@ import { CAPI, PROVIDER_TYPES } from '../../types/capi';
 import ProviderConfig from './ProviderConfig.vue';
 import { set } from '@shell/utils/object';
 
+const CUSTOM = 'custom';
+
 export default {
   name: 'CreateProvider',
 
@@ -37,23 +39,20 @@ export default {
   },
   async beforeMount() {
     this.capiProviders = await this.$store.dispatch('management/findAll', { type: CAPI.PROVIDER });
-    const name = this.value.spec?.name;
+    const name = this.value.spec?.name || this.value.metadata?.name;
 
     if (!name) {
       return;
     }
     if (this.value.spec?.fetchConfig && !this.subTypes.find(({ id }) => id === name)) {
-      this.selectType('custom');
+      this.selectType(CUSTOM);
     } else {
       this.selectType(name);
     }
   },
 
   data() {
-    const route = this.$route;
-    const subType = route?.query[SUB_TYPE] || null;
-
-    return { subType, capiProviders: [] };
+    return { subType: null, capiProviders: [] };
   },
 
   computed: {
@@ -100,7 +99,7 @@ export default {
       return this.capiProviders.reduce((types, p) => {
         const { name } = p?.spec || {};
 
-        if (!types.includes(name) && name !== 'custom') {
+        if (!types.includes(name) && name !== CUSTOM) {
           types.push(name);
         }
 


### PR DESCRIPTION
Covered cases:
1. Create azure provider using yaml:
apiVersion: v1
kind: Namespace
metadata:
  name: capz-system
---
apiVersion: turtles-capi.cattle.io/v1alpha1
kind: CAPIProvider
metadata:
  name: azure
  namespace: capz-system
spec:
  type: infrastructure
  name: azure
  
Before:
Cannot read properties of undefined (reading 'name') error is thrown
Now:
No error is shown

Go to edit pre-installed 'fleet' provider:
Before: 
A provider selection step is shown
Now:
It shows editing custom provider. The validation error should go away once https://github.com/rancher/capi-ui-extension/pull/155 is merged
