### PR TITLE
Fixed enabling Azure credential on edit

### DIFF
--- a/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
+++ b/pkg/capi/edit/turtles-capi.cattle.io.capiprovider/ProviderConfig.vue
@@ -112,7 +112,7 @@ export default {
       ],
       allNamespaces:         [],
       credentialComponent:     providerDetails?.credential,
-      useCredential:       !!providerDetails?.credentialRequired,
+      useCredential:       !!providerDetails?.credentialRequired || (this.mode === _EDIT && !!this.value?.spec?.credentials?.rancherCloudCredentialNamespaceName),
       credentialRequired:  providerDetails?.credentialRequired
     };
   },
@@ -171,7 +171,7 @@ export default {
       return this.credentialComponent && !this.value.spec.credentials?.rancherCloudCredentialNamespaceName;
     },
     rancherCloudCredentialNamespaceName() {
-      return this.useCredential && this.credentialComponent && !this.value.spec?.credentials?.rancherCloudCredentialNamespaceName;
+      return this.value.spec?.credentials?.rancherCloudCredentialNamespaceName || '';
     },
 
     providerDisplayName() {
@@ -442,7 +442,7 @@ export default {
 
       <template v-if="useCredential">
         <SelectCredential
-          v-model:value="value.spec.credentials.rancherCloudCredentialNamespaceName"
+          :value="rancherCloudCredentialNamespaceName"
           :mode="mode"
           :provider="credentialComponent"
           :cancel="cancelCredential"


### PR DESCRIPTION
Fixed errors when enabling Azure credential on edit
To test:
1. Create Azure provider without credentials
2. Edit -> Enable credential -> Save
3. Edit -> Selected credential should be enabled and present
4. Try disabling and enabling and check that no errors are thrown