### PR TITLE
use generic saveYaml method when editing a cc

### DIFF
--- a/pkg/capi/models/cluster.x-k8s.io.clusterclass.js
+++ b/pkg/capi/models/cluster.x-k8s.io.clusterclass.js
@@ -32,8 +32,14 @@ export default class ClusterClass extends SteveModel {
   }
 
   saveYaml(yaml) {
-    const localCluster = this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
+    const isCreate = !this.id;
 
-    return localCluster.doAction('apply', { yaml });
+    if (isCreate) {
+      const localCluster = this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
+
+      return localCluster.doAction('apply', { yaml });
+    } else {
+      return this._saveYaml(yaml);
+    }
   }
 }


### PR DESCRIPTION
Fixes #170 

Clusterclass's saveYaml uses the `apply` action to allow users to create multiple resources from one yaml. The 'apply' action doesn't work on edit: this PR updates the clusterclass model to use the generic saveYaml resource method when editing a cluster class.